### PR TITLE
feat:playwrightの設定ファイルを作成

### DIFF
--- a/outputs/playwright/theInternet/package.json
+++ b/outputs/playwright/theInternet/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "the-internet-tests",
+  "version": "1.0.0",
+  "description": "Playwright tests for the-internet.herokuapp.com",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.42.1",
+    "@types/node": "^20.11.24"
+  }
+} 

--- a/outputs/playwright/theInternet/playwright.config.ts
+++ b/outputs/playwright/theInternet/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'https://the-internet.herokuapp.com',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+  ],
+}); 


### PR DESCRIPTION
## 概要
- playwright用のディレクトリに設定ファイルを作成。
- the-internetに対するテストをひとつのプロジェクトとして扱う。

## 変更内容
- package.json、playwright.config.tsを作成。